### PR TITLE
feat : Create Admin User

### DIFF
--- a/src/main/java/taxi/tago/config/DataInitializer.java
+++ b/src/main/java/taxi/tago/config/DataInitializer.java
@@ -1,0 +1,49 @@
+package taxi.tago.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import taxi.tago.constant.UserRole;
+import taxi.tago.entity.User;
+import taxi.tago.repository.UserRepository;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${admin.email}")
+    private String adminEmail;
+
+    @Value("${admin.password}")
+    private String adminPassword;
+
+    @Override
+    public void run(String... args) throws Exception {
+        // 관리자 계정이 이미 존재하는지 확인
+        if (userRepository.findByEmail(adminEmail).isEmpty()) {
+            // 관리자 계정 생성
+            String encodedPassword = passwordEncoder.encode(adminPassword);
+            
+            User admin = new User();
+            admin.setEmail(adminEmail);
+            admin.setPassword(encodedPassword);
+            admin.setRole(UserRole.ADMIN);
+            admin.setLastActiveAt(LocalDateTime.now());
+            
+            userRepository.save(admin);
+            log.info("관리자 계정이 생성되었습니다: {}", adminEmail);
+        } else {
+            log.info("관리자 계정이 이미 존재합니다: {}", adminEmail);
+        }
+    }
+}
+

--- a/src/main/java/taxi/tago/constant/UserRole.java
+++ b/src/main/java/taxi/tago/constant/UserRole.java
@@ -1,0 +1,7 @@
+package taxi.tago.constant;
+
+public enum UserRole {
+    ADMIN, // 관리자
+    USER   // 일반 사용자
+}
+

--- a/src/main/java/taxi/tago/controller/AdminController.java
+++ b/src/main/java/taxi/tago/controller/AdminController.java
@@ -1,0 +1,69 @@
+package taxi.tago.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import taxi.tago.dto.AdminLoginRequest;
+import taxi.tago.dto.AdminLoginResponse;
+import taxi.tago.service.AdminService;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final AdminService adminService;
+
+    /**
+     * 관리자 로그인
+     */
+    @PostMapping("/login")
+    public ResponseEntity<AdminLoginResponse> login(@RequestBody AdminLoginRequest request) {
+        try {
+            // 입력값 검증
+            if (request.getEmail() == null || request.getEmail().trim().isEmpty()) {
+                return ResponseEntity.badRequest().body(new AdminLoginResponse(
+                        false,
+                        "이메일을 입력해주세요.",
+                        null,
+                        null
+                ));
+            }
+
+            if (request.getPassword() == null || request.getPassword().trim().isEmpty()) {
+                return ResponseEntity.badRequest().body(new AdminLoginResponse(
+                        false,
+                        "비밀번호를 입력해주세요.",
+                        request.getEmail(),
+                        null
+                ));
+            }
+
+            // 로그인 처리
+            var user = adminService.login(request.getEmail(), request.getPassword());
+
+            return ResponseEntity.ok(new AdminLoginResponse(
+                    true,
+                    "로그인 성공",
+                    user.getEmail(),
+                    user.getRole()
+            ));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(new AdminLoginResponse(
+                    false,
+                    e.getMessage(),
+                    request.getEmail(),
+                    null
+            ));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new AdminLoginResponse(
+                    false,
+                    "로그인 처리 중 오류가 발생했습니다: " + e.getMessage(),
+                    request.getEmail(),
+                    null
+            ));
+        }
+    }
+}
+

--- a/src/main/java/taxi/tago/dto/AdminLoginRequest.java
+++ b/src/main/java/taxi/tago/dto/AdminLoginRequest.java
@@ -1,0 +1,14 @@
+package taxi.tago.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdminLoginRequest {
+    private String email; // 관리자 이메일 (아이디)
+    private String password; // 비밀번호
+}
+

--- a/src/main/java/taxi/tago/dto/AdminLoginResponse.java
+++ b/src/main/java/taxi/tago/dto/AdminLoginResponse.java
@@ -1,0 +1,18 @@
+package taxi.tago.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import taxi.tago.constant.UserRole;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminLoginResponse {
+    private boolean success;
+    private String message;
+    private String email;
+    private UserRole role; // ADMIN 또는 USER
+}

--- a/src/main/java/taxi/tago/entity/User.java
+++ b/src/main/java/taxi/tago/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import taxi.tago.constant.UserRole;
 import java.time.LocalDateTime;
 
 @Entity
@@ -22,6 +23,10 @@ public class User {
 
     @Column(nullable = false, length = 255)
     private String password; // 비밀번호 (암호화된 값)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role = UserRole.USER; // 사용자 역할 (ADMIN, USER)
 
     // 추가 작성
 

--- a/src/main/java/taxi/tago/service/AdminService.java
+++ b/src/main/java/taxi/tago/service/AdminService.java
@@ -1,0 +1,50 @@
+package taxi.tago.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import taxi.tago.constant.UserRole;
+import taxi.tago.entity.User;
+import taxi.tago.repository.UserRepository;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 관리자 로그인 처리
+     * @param email 관리자 이메일
+     * @param password 비밀번호
+     * @return 로그인 성공 시 User 객체, 실패 시 null
+     */
+    public User login(String email, String password) {
+        // 1. 이메일로 사용자 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 계정입니다."));
+
+        // 2. 관리자 권한 확인
+        if (user.getRole() != UserRole.ADMIN) {
+            throw new IllegalArgumentException("관리자 권한이 없습니다.");
+        }
+
+        // 3. 비밀번호 확인
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 4. 마지막 활동 시간 업데이트
+        user.setLastActiveAt(LocalDateTime.now());
+        userRepository.save(user);
+
+        log.info("관리자 로그인 성공: {}", email);
+        return user;
+    }
+}
+


### PR DESCRIPTION
<관리자 계정 로그인>
- 기존에 관리자용 회원가입은 없고 하나의 계정으로 다같이 사용하는게 생각나서 일단 하나의 관리자용 계정을 미리 더미데이터 삽입하듯 DB에 심어놓는 것으로 해놓았습니다.
-> 추후에 서버 데이터에 관리자용 계정 아이디/비밀번호 지정

<application.properties에 추가할 것>
# Admin Account Settings
admin.email=자기 서울여대 웹메일 주소
admin.password=웹 메일 비밀번호